### PR TITLE
Run tox via GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,3 @@
-# Fixes octo-org/octo-repo#100
-
 name: Run tests with tox
 
 on:
@@ -11,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        # Not all Python versions are avalaible for linux AND x64
+        # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+# Fixes octo-org/octo-repo#100
+
+name: Run tests with tox
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox -vv

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,16 @@ recreate = True
 [tox:hudson]
 downloadcache = {toxworkdir}/_download
 
+[gh-actions]
+python =
+    2.6: py26
+    2.7: py27
+    3.3: py33
+    3.4: py34
+    3.5: py35
+    3.6: py36
+    3.7: py37
+
 [testenv]
 deps =
     pytest>=2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36,py37
+envlist = py27,py33,py34,py35,py36,py37,py38,py39,py310
 recreate = True
 
 [tox:hudson]
@@ -7,21 +7,26 @@ downloadcache = {toxworkdir}/_download
 
 [gh-actions]
 python =
-    2.6: py26
     2.7: py27
     3.3: py33
     3.4: py34
     3.5: py35
     3.6: py36
     3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv]
+description = run test suite under {basepython}
 deps =
-    pytest>=2.0.0
+    pytest >=4, <7; python_version<'3.10'
+    pytest >=6.2.5, <7; python_version>='3.10'
+#    pytest-cov >=2, <3
+    pytest-cov
     six
     requests
 commands =
   py.test -v \
     --junitxml=junit-{envname}.xml \
-    [] # substitute with tox' positional arguments
-
+    {posargs}


### PR DESCRIPTION
tox is now run via Github Action. This does not fix any errors in the tests themselves!

This PR addresses #5.