### PR TITLE
Update changelog for the upcoming v0.5.1 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+0.5.1 (2021-11-18)
+------------------
+
+Regenerate included certificate to use SHA-256 hash to avoid OpenSSL errors (fixes #2).
+Add support for Python 3.10.
+Drop support for Python 2.6.
+Migrate repository to Github and update project metadata.
+
 0.5 (2018-09-20)
 ----------------
 


### PR DESCRIPTION
I figured I'd get this started. I listed Nov 18 as the release date, but that's just a placeholder; we should substitute in whatever we want to be the actual release date before merging this.

Please go ahead and add/change anything else that should be in the changelog.

Closes #9