### PR TITLE
Support chunked encoding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,14 +73,25 @@ poking around in the code itself.
     following attributes:
 
     * ``code`` - HTTP response code (int)
-    * ``content`` - content of next response (str)
+    * ``content`` - content of next response (str, bytes, or iterable of either)
     * ``headers`` - response headers (dict)
+    * ``chunked`` - whether to chunk-encode the response (enumeration)
 
-    Once these attribute are set, all subsequent requests will be answered with
+    Once these attributes are set, all subsequent requests will be answered with
     these values until they are changed or the server is stopped. A more
     convenient way to change these is ::
 
-        httpserver.serve_content(content=None, code=200, headers=None)
+        httpserver.serve_content(content=None, code=200, headers=None, chunked=pytest_localserver.http.Chunked.NO)
+
+    The ``chunked`` atribute or parameter can be set to
+
+    * ``Chunked.YES``, telling the server to always apply chunk encoding
+    * ``Chunked.NO``, telling the server to never apply chunk encoding
+    * ``Chunked.AUTO``, telling the server to apply chunk encoding only if
+        the ``Transfer-Encoding`` header includes ``chunked``
+
+    If chunk encoding is applied, each str or bytes in ``content`` becomes one
+    chunk in the response.
 
     The server address can be found in property
 

--- a/pytest_localserver/http.py
+++ b/pytest_localserver/http.py
@@ -7,6 +7,7 @@ import json
 import sys
 import threading
 
+from werkzeug.datastructures import Headers
 from werkzeug.serving import make_server
 from werkzeug.wrappers import Response, Request
 
@@ -111,9 +112,10 @@ class ContentServer(WSGIServer):
                 # this probably means that content is not iterable, so just go
                 # ahead in case it's some type that Response knows how to handle
                 pass
-        self.content, self.code = (content, code)
+        self.content = content
+        self.code = code
         if headers:
-            self.headers = headers
+            self.headers = Headers(headers)
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
I came up with this patch set a while ago for another project of mine that was experiencing errors only when receiving chunk-encoded data. It adds the ability to serve a chunked response. I know that users can do this themselves using a custom WSGI application, but since chunking is a part of the HTTP 1.1 standard, it's a common enough use case that it _might_ be reasonable to handle it directly.

I'd be curious for your opinions @redtoad and @coordt about whether this makes sense to add to the project.