### PR TITLE
Disable fail-fast in Github Actions configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ jobs:
         # Not all Python versions are avalaible for linux AND x64
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
By default, Github Actions has the fail-fast option enabled, which means that the first job to fail in a matrix causes the whole matrix to be immediately canceled. This makes it impossible to identify when a bug causing a job failure is specific to certain versions of Python. In this PR I'm setting the option to false so that each job will run to completion even if one fails.