### PR TITLE
List required Python version as 2.7 or 3.3+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     url='https://github.com/pytest-dev/pytest-localserver',
 
     packages=['pytest_localserver'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
     install_requires=[
         'werkzeug>=0.10'
     ],


### PR DESCRIPTION
This commit adds `python_requires` to the setup script as recommended by https://packaging.python.org/guides/dropping-older-python-versions/. Specifically, it seems to suggest adding `python_requires` _first_ before modifying it to drop support for older versions; I guess this is so that people running older versions of Python for which support gets dropped (like 2.7) will at least find _some_ version of the package that lists itself as being compatible with that version of Python.

I plan to follow this up with another PR that drops Python 2 support, but I figured we might want to make a post release with just this change before dropping support for Python 2.