### PR TITLE
Drop support for older Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # Not all Python versions are avalaible for linux AND x64
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
       fail-fast: false
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -178,8 +178,7 @@ always welcome!::
 
 If you find any bugs, please file a `report`_.
 
-Test can be run with tox. Note that you need virtualenv<1.8 to run tests for
-Python 2.4.
+Test can be run with tox.
 
 I already have a couple of ideas for future versions:
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     url='https://github.com/pytest-dev/pytest-localserver',
 
     packages=['pytest_localserver'],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
+    python_requires='>=3.5',
     install_requires=[
         'werkzeug>=0.10'
     ],
@@ -64,11 +64,8 @@ setup(
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,py37,py38,py39,py310
+envlist = py35,py36,py37,py38,py39,py310
 recreate = True
 
 [tox:hudson]
@@ -7,9 +7,6 @@ downloadcache = {toxworkdir}/_download
 
 [gh-actions]
 python =
-    2.7: py27
-    3.3: py33
-    3.4: py34
     3.5: py35
     3.6: py36
     3.7: py37


### PR DESCRIPTION
This builds on #24 to drop support for Python 2, when we're ready for that.