### PR TITLE
Bump version to 0.5.1.post0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.5.1.post0 (2021-12-13)
+------------------------
+
+Explicitly list supported Python versions with python_requires in setup.py.
+
 0.5.1 (2021-11-18)
 ------------------
 

--- a/pytest_localserver/__init__.py
+++ b/pytest_localserver/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.5.1'
+VERSION = '0.5.1.post0'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, Command
 import sys
 
 
-VERSION = '0.5.1'
+VERSION = '0.5.1.post0'
 
 
 def read(fname):


### PR DESCRIPTION
This PR updates the package version to 0.5.1.post0 and adds a changelog entry. I've tentatively set the date at December 13 (Monday), and if this is approved in time, I'll push the release to PyPI then.