### PR TITLE
Use aiosmtpd for the smtp.Server class

### DIFF
--- a/pytest_localserver/smtp.py
+++ b/pytest_localserver/smtp.py
@@ -16,6 +16,18 @@ import threading
 
 PY35_OR_NEWER = sys.version_info[:2] >= (3, 5)
 
+
+class MessageDetails:
+    def __init__(self, peer, mailfrom, rcpttos, *, mail_options=None, rcpt_options=None):
+        self.peer = peer
+        self.mailfrom = mailfrom
+        self.rcpttos = rcpttos
+        if mail_options:
+            self.mail_options = mail_options
+        if rcpt_options:
+            self.rcpt_options = rcpt_options
+
+
 class Server (smtpd.SMTPServer, threading.Thread):
 
     """
@@ -61,11 +73,7 @@ class Server (smtpd.SMTPServer, threading.Thread):
             message = email.message_from_string(data)
         # on the message, also set the envelope details
 
-        class Bunch:
-            def __init__(self, **kwds):
-                vars(self).update(kwds)
-
-        message.details = Bunch(
+        message.details = MessageDetails(
             peer=peer,
             mailfrom=mailfrom,
             rcpttos=rcpttos,

--- a/pytest_localserver/smtp.py
+++ b/pytest_localserver/smtp.py
@@ -84,7 +84,7 @@ class Server(aiosmtpd.controller.Controller):
             assert hasattr(self, 'port')
             return
 
-        self.addr = self.server.sockets[0].getsockname()
+        self.addr = self.server.sockets[0].getsockname()[:2]
 
         # Work around a bug/missing feature in aiosmtpd (https://github.com/aio-libs/aiosmtpd/issues/276)
         if self.port == 0:

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
     packages=['pytest_localserver'],
     python_requires='>=3.5',
     install_requires=[
-        'werkzeug>=0.10'
+        'werkzeug>=0.10',
+        'aiosmtpd'
     ],
     cmdclass={'test': PyTest},
     tests_require=[

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -39,6 +39,13 @@ def test_smtpserver_funcarg(smtpserver):
     assert smtpserver.accepting and smtpserver.addr
 
 
+def test_smtpserver_addr(smtpserver):
+    host, port = smtpserver.addr
+    assert isinstance(host, str)
+    assert isinstance(port, int)
+    assert port > 0
+
+
 def test_server_is_killed(smtpserver):
     assert smtpserver.is_alive()
     smtpserver.stop()


### PR DESCRIPTION
I made these changes to switch from using Python's standard [smtpd](https://docs.python.org/3/library/smtpd.html) module, which is deprecated, to the external [aiosmtpd](https://aiosmtpd.readthedocs.io/en/latest/) package. The changes are somewhat substantial, but most of them are just meant to keep the Server class interface backward compatible and to support old versions of Python and smtpd. Once we drop support for older versions, it will simplify the implementation quite a bit.

One thing to note: it's not entirely clear how actively aiosmtpd is maintained, since the last commit on Github was over a year ago and there's a featured issue asking for help with the package. So I can imagine a future where the suggested replacement for smtpd changes to something other than aiosmtpd. It's _possible_ we might want to defer this merge request until the status of aiosmtpd as a replacement for smtpd becomes more clear.

Closes #12 