### PR TITLE
Update changelog for the upcoming 0.6.0 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+0.6.0 (2022-05-05)
+------------------
+
+Drop support for Python 3.3 and 3.4
+Use setuptools_scm for managing versions of this package
+Support sending chunked responses from the HTTP server
+Switch SMTP server backend from smtpd to aiosmtpd
+
 0.5.1.post0 (2021-12-13)
 ------------------------
 


### PR DESCRIPTION
Everything listed under the 0.6.0 release milestone has been done (except this PR itself), so I figure it's time to release a new version. As usual, the April 27 date is just a placeholder; we should substitute in whatever we want to be the actual release date before merging this.

Anything else that should be added?