### PR TITLE
Remove redudant `wheel` dep from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >=42", "setuptools_scm[toml] >=3.4.1", "wheel"]
+requires = ["setuptools >=42", "setuptools_scm[toml] >=3.4.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
The `setuptools` PEP517 backend provides the dependency on `wheel`
implicitly.  The explicit dep is unnecessary and specifying it is
no longer the recommended practice per setuptools documentation.