### PR TITLE
Fix a warning about dash-separated cfg key

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 
 [metadata]
-description-file = README.rst
+description_file = README.rst


### PR DESCRIPTION
```
/usr/lib/python3.10/site-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
```