### PR TITLE
Make aiosmtpd dependency optional

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # Not all Python versions are available for linux AND x64
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11.0-beta - 3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
         extra: ['', '-smtp']
       fail-fast: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ jobs:
         # Not all Python versions are available for linux AND x64
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
+        extra: ['', '-smtp']
       fail-fast: false
 
     steps:
@@ -25,4 +26,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox
     - name: Test with tox
-      run: tox -vv -e py
+      run: tox -vv -e py${{ matrix.extra }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install tox
     - name: Test with tox
-      run: tox -vv
+      run: tox -vv -e py

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     maintainer='David Zaslavsky',
     maintainer_email='diazona@ellipsix.net',
     license='MIT License',
-    description='py.test plugin to test server connections locally.',
+    description='pytest plugin to test server connections locally.',
     long_description=read('README.rst'),
     url='https://github.com/pytest-dev/pytest-localserver',
 
@@ -53,7 +53,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
 
-    keywords='py.test pytest server localhost http smtp',
+    keywords='pytest pytest server localhost http smtp',
     classifiers=[
         'Framework :: Pytest',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
 
-    keywords='pytest pytest server localhost http smtp',
+    keywords='pytest server localhost http smtp',
     classifiers=[
         'Framework :: Pytest',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,12 @@ setup(
     python_requires='>=3.5',
     install_requires=[
         'werkzeug>=0.10',
-        'aiosmtpd'
     ],
+    extras_require={
+        'smtp': [
+            'aiosmtpd',
+        ],
+    },
     cmdclass={'test': PyTest},
     tests_require=[
         'pytest>=2.0.0',

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -1,3 +1,4 @@
+import pytest
 import smtplib
 
 try:  # python 3
@@ -5,7 +6,10 @@ try:  # python 3
 except ImportError:  # python 2?
     from email.MIMEText import MIMEText
 
-from pytest_localserver import plugin, smtp
+from pytest_localserver import plugin
+
+
+smtp = pytest.importorskip('pytest_localserver.smtp')
 
 
 def send_plain_email(to, from_, subject, txt, server=('localhost', 25)):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39,310}{,-smtp}
+envlist = py{35,36,37,38,39,310,311,py3}{,-smtp}
 recreate = True
 isolated_build = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,6 @@ deps =
 extras =
     smtp
 commands =
-  py.test -v \
+  pytest -v \
     --junitxml=junit-{envname}.xml \
     {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -6,15 +6,6 @@ isolated_build = True
 [tox:hudson]
 downloadcache = {toxworkdir}/_download
 
-[gh-actions]
-python =
-    3.5: py35
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310
-
 [testenv]
 description = run test suite under {basepython}
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,8 @@ deps =
     pytest-cov
     six
     requests
+extras =
+    smtp
 commands =
   py.test -v \
     --junitxml=junit-{envname}.xml \

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,py39,py310
+envlist = py{35,36,37,38,39,310}{,-smtp}
 recreate = True
 isolated_build = True
 
@@ -16,7 +16,7 @@ deps =
     six
     requests
 extras =
-    smtp
+    smtp: smtp
 commands =
   pytest -v \
     --junitxml=junit-{envname}.xml \


### PR DESCRIPTION
Move the aiosmtpd dependency to "smtp" extra, and handle the lack of it
gracefully in tests.  The aiosmtpd package is no longer maintained
and had major bugs that lead to it being queued for removal from Gentoo.
FWICS all packages in Gentoo that are using pytest-localserver are only
using the HTTP support.