### PR TITLE
Add linter for workflow actions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,8 @@ repos:
     hooks:
     -   id: pyupgrade
         args: [--py3-plus]
+
+-   repo: https://github.com/rhysd/actionlint
+    rev: v1.6.15
+    hooks:
+    -   id: actionlint-docker


### PR DESCRIPTION
I'm adding a pre-commit hook that uses actionlint to verify that the Github workflow files are syntactically correct. From what I can find, actionlint seems to be pretty much the standard tool for checking workflow files.