### PR TITLE
Relax dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,15 @@ jobs:
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11.0-beta - 3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
         extra: ['', '-smtp']
+        # The forced pytest versions correspond with the lower bounds in tox.ini
+        pytest-version: ['', '--force-dep pytest==4', '--force-dep pytest==6.2.4']
+        exclude:
+          - python-version: '3.5'
+            pytest-version: '--force-dep pytest==6.2.4'
+          - python-version: '3.10'
+            pytest-version: '--force-dep pytest==4'
+          - python-version: '3.11.0-beta - 3.11'
+            pytest-version: '--force-dep pytest==4'
       fail-fast: false
 
     steps:
@@ -30,4 +39,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox
     - name: Test with tox
-      run: tox -vv -e py${{ matrix.extra }}
+      run: tox -vv -e py${{ matrix.extra }} ${{ matrix.pytest-version }}

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,13 @@ downloadcache = {toxworkdir}/_download
 [testenv]
 description = run test suite under {basepython}
 deps =
-    pytest >=4, <7; python_version<'3.10'
-    pytest >=6.2.5, <7; python_version>='3.10'
-#    pytest-cov >=2, <3
+    # Future major versions of pytest may break backwards compatibility in a way
+    # that prevents them from working with this package, so we prevent testing
+    # with major versions that haven't been released yet. Each time a new major
+    # version of pytest is released, once it's confirmed to work with this
+    # package, we should bump this limit to the next major version.
+    pytest >=4, <8; python_version<'3.10'
+    pytest >=6.2.5, <8; python_version>='3.10'
     pytest-cov
     six
     requests

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,14 @@ deps =
     # with major versions that haven't been released yet. Each time a new major
     # version of pytest is released, once it's confirmed to work with this
     # package, we should bump this limit to the next major version.
+    #
+    # The lower bounds come from testing with different pytest versions using
+    # tox's --force-dep option to find the earliest versions of pytest that are
+    # known to work. If you add code that breaks with an old version of pytest,
+    # feel free to raise these bounds to represent the earliest version that
+    # works with your code.
     pytest >=4, <8; python_version<'3.10'
-    pytest >=6.2.5, <8; python_version>='3.10'
+    pytest >=6.2.4, <8; python_version>='3.10'
     pytest-cov
     six
     requests

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,9 @@ deps =
     # tox's --force-dep option to find the earliest versions of pytest that are
     # known to work. If you add code that breaks with an old version of pytest,
     # feel free to raise these bounds to represent the earliest version that
-    # works with your code.
+    # works with your code. Don't forget to modify the corresponding entries in
+    # the Github workflows configuration file if you do change these lower
+    # bounds.
     pytest >=4, <8; python_version<'3.10'
     pytest >=6.2.4, <8; python_version>='3.10'
     pytest-cov


### PR DESCRIPTION
This expands the range of allowed pytest versions to be 6.2.4 to 7.X (inclusive), and adds some more tests to verify functionality of the package with the edge versions.

Closes #41 