### PR TITLE
Skip duplicate actions when pushing in this repository

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/
+    if: >
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       matrix:
         # Not all Python versions are available for linux AND x64


### PR DESCRIPTION
Currently when someone pushes a branch directly to pytest-localserver, we get two copies of each Github action, one for the push and one for the pull request. This change should skip the pull_request action for branches pushed directly into this repository. It won't affect branches coming from other people's forks.