### PR TITLE
Mark the package as incompatible with aiosmtpd 1.4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     install_requires=["werkzeug>=0.10"],
     extras_require={
         "smtp": [
-            "aiosmtpd",
+            "aiosmtpd <1.4.3",
         ],
     },
     cmdclass={"test": PyTest},


### PR DESCRIPTION
aiosmtpd 1.4.3 removed the method aiosmtpd.controller.Controller._stop() which this package's SMTP server implementation was using. That broke the SMTP server plugin. This is my fault; it wasn't a good idea to use a private method from another package, but I was in a hurry to get something working and I didn't get to figure out how to implement the SMTP server using only the public API of aiosmtpd.

We're working on a proper fix - see issue #53 - but for now I'm just marking this package as incompatible with aiosmtpd 1.4.3 and up, as an aid to people trying to resolve dependencies.

I'd like to push a post-release version (0.7.0.post0) with this change.