### PR TITLE
Replace the _stop method, which was removed from aiosmtp 1.4.3, with the cancel_tasks method

### DIFF
--- a/pytest_localserver/smtp.py
+++ b/pytest_localserver/smtp.py
@@ -130,7 +130,11 @@ class Server(aiosmtpd.controller.Controller):
         #   be called more than once safely
         # - It passes the timeout argument to Thread.join()
         if self.loop.is_running():
-            self.loop.call_soon_threadsafe(self.cancel_tasks)
+            try:
+                self.loop.call_soon_threadsafe(self.cancel_tasks)
+            except AttributeError:
+                # for aiosmtpd < 1.4.3
+                self.loop.call_soon_threadsafe(self._stop)
         if self._thread is not None:
             self._thread.join(timeout)
             self._thread = None

--- a/pytest_localserver/smtp.py
+++ b/pytest_localserver/smtp.py
@@ -130,7 +130,7 @@ class Server(aiosmtpd.controller.Controller):
         #   be called more than once safely
         # - It passes the timeout argument to Thread.join()
         if self.loop.is_running():
-            self.loop.call_soon_threadsafe(self._stop)
+            self.loop.call_soon_threadsafe(self.cancel_tasks)
         if self._thread is not None:
             self._thread.join(timeout)
             self._thread = None


### PR DESCRIPTION
Fixes #53 .