### PR TITLE
Use older Ubuntu for testing with Python 3.5 and 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: '${{ matrix.os }}'
     # https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/
     if: >
       github.event_name != 'pull_request'
@@ -15,17 +15,25 @@ jobs:
       matrix:
         # Not all Python versions are available for linux AND x64
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11.0-beta - 3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
+        os: ['ubuntu-latest']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
         extra: ['', '-smtp']
         # The forced pytest versions correspond with the lower bounds in tox.ini
         pytest-version: ['', '--force-dep pytest==4', '--force-dep pytest==6.2.4']
+        include:
+        - os: 'ubuntu-20.04'
+          python-version: '3.5'
+          pytest-version: ''
+        - os: 'ubuntu-20.04'
+          python-version: '3.5'
+          pytest-version: '--force-dep pytest==4'
+        - os: 'ubuntu-20.04'
+          python-version: '3.6'
         exclude:
-          - python-version: '3.5'
-            pytest-version: '--force-dep pytest==6.2.4'
-          - python-version: '3.10'
-            pytest-version: '--force-dep pytest==4'
-          - python-version: '3.11.0-beta - 3.11'
-            pytest-version: '--force-dep pytest==4'
+        - python-version: '3.10'
+          pytest-version: '--force-dep pytest==4'
+        - python-version: '3.11'
+          pytest-version: '--force-dep pytest==4'
       fail-fast: false
 
     steps:


### PR DESCRIPTION
This commit changes the Github Actions workflow configuration to use an older version of Ubuntu for testing on Python 3.5 and 3.6 - namely Ubuntu 20.04 instead of the current default 22.04. The runners that Github provides with Ubuntu 22.04 don't support versions of Python prior to 3.7.

We will remove support for Python <3.7 at some point, when a code change makes it necessary, but for now there happens to be nothing in the code that breaks with Python 3.5 or 3.6 and it's easy enough to support those versions, which is why I'm not removing support for them entirely yet.

I also upgraded the workflow configuration from the beta version of Python 3.11 to the final release version.

By merging this I hope to get all tests passing in #55.