### PR TITLE
Mark the package as being compatible with Python 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Testing",
     ],
 )


### PR DESCRIPTION
I'm adding the Python 3.11 trove classifier.