### PR TITLE
Update the AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,15 @@
 Sebastian Rahlf <basti@redtoad.de> (maintainer)
 Muhammad Hallaj Subery <hallajs@gmail.com>
 Thomas Weißschuh <thomas@t-8ch.de>
+Ulrich Petri <ulo@ulo.pe>
+Yuya Kusakabe <yuya.kusakabe@gmail.com>
+Bruno Oliveira <nicoddemus@gmail.com>
 Benjamin Wohlwend <piquadrat@gmail.com>
-Jason R. Coombs
+Jason R. Coombs <jaraco@jaraco.com>
 David Zaslavsky <diazona@ellipsix.net> (maintainer)
 Corey Oordt <coreyoordt@gmail.com> (maintainer)
+Kian-Meng Ang <kianmeng@cpan.org>
+Michał Górny <mgorny@gentoo.org>
+Hasan Ramezani <hasan.r67@gmail.com>
+Felix Yan <felixonmars@archlinux.org>
+Henri Hulski <henri.hulski@gazeta.pl>


### PR DESCRIPTION
We haven't been updating the AUTHORS file as various people have added their contributions to the project, so in this commit I'm catching up on those updates. It's important for both legal and ethical reasons that everyone gets appropriate credit for their contributions.

I've taken the list of authors from the commit history. The list of authors in the file is ordered chronologically by their first commit or first interaction with the project (as far as I'm aware), which seems consistent with the order that was there before.