### PR TITLE
Update changelog for the upcoming 0.7.1 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,12 @@
+0.7.1 (2023-01-29)
+------------------
+
+Update SMTP server code to work with aiosmtpd >=1.4.3
+Fix GitHub Actions configuration for Python 3.5 and 3.6
+Add support for Python 3.11 (or at least, list it explicitly in the classifiers)
+Update the AUTHORS file
+Add a workflow to push packages to PyPI using GitHub Actions
+
 0.7.0 (2022-08-30)
 ------------------
 


### PR DESCRIPTION
This is the last step to take before releasing version 0.7.1.

Since I forgot to do this earlier, I'm pushing the target date on the milestone to Sunday; a couple more days shouldn't hurt anything. We can release earlier if I get approvals first, though.