### PR TITLE
Convert to trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     environment: test-pypi
+    permissions:
+      # this permission is mandatory for trusted publishing
+      id-token: write
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -39,7 +42,6 @@ jobs:
     - name: Publish packages to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: '${{ secrets.TEST_PYPI_API_TOKEN }}'
         repository_url: https://test.pypi.org/legacy/
         print_hash: true
   publish-to-pypi:
@@ -47,6 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     environment: pypi
+    permissions:
+      # this permission is mandatory for trusted publishing
+      id-token: write
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -55,5 +60,4 @@ jobs:
     - name: Publish packages to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: '${{ secrets.PYPI_API_TOKEN }}'
         print_hash: true


### PR DESCRIPTION
I based this change on the [official PyPI documentation](https://docs.pypi.org/trusted-publishers/) as well as a [blog post](https://pgjones.dev/blog/trusted-plublishing-2023/) walking through an example of how to implement trusted publishing for a Python project.
  
The diff is fairly minimal. All it does is remove the password used to authenticate to PyPI, which we don't need anymore, and add a permission needed for trusted publishing to operate.

This commit will be accompanied by some configuration in the project settings on PyPI to allow this specific workflow to act as a trusted publisher. Specifically, I'm going to add a trusted publisher with the following settings:

- Owner: `pytest-dev`
- Repository name: `pytest-localserver`
- Workflow name: `release.yml`
- Environment name: `pypi`

and on Test PyPI I'm going to do the same except using `test-pypi` as the environment. I'll make those changes in a couple days, as long as no objections are raised before then, and then I'll try creating a test release and publishing it to Test PyPI (not regular PyPI) before merging this PR so I can make sure the flow works. After I've successfully published a release to both Test PyPI and regular PyPI - that will presumably be release 0.8 - I'll remove the secret tokens from both the `pypi` and `test-pypi` environments in this Github project.

Resolves #61 