### PR TITLE
Make pypi deployment dependent on test-pypi deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,8 @@ jobs:
   publish-to-test-pypi:
     name: Publish packages to Test PyPI
     runs-on: ubuntu-latest
-    needs: [build]
+    needs:
+    - build
     environment: test-pypi
     permissions:
       # this permission is mandatory for trusted publishing
@@ -47,7 +48,9 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     runs-on: ubuntu-latest
-    needs: [build]
+    needs:
+    - build
+    - publish-to-test-pypi
     environment: pypi
     permissions:
       # this permission is mandatory for trusted publishing


### PR DESCRIPTION
This commit changes the deployment to PyPI to be dependent on successful deployment to Test PyPI. Without this we would have to manually check that the deployment to Test PyPI succeeded before deploying to PyPI, and there's really no point in making that a manual process. (Or, a person could just deploy to PyPI directly without even waiting for the Test PyPI deployment to succeed and in that case there's no point in even deploying to Test PyPI first.)

I was inspired to do this by looking at the release workflow for some other project, but I forget which one it was.