### PR TITLE
Remove /usr/bin/env lines

### DIFF
--- a/pytest_localserver/plugin.py
+++ b/pytest_localserver/plugin.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011 Sebastian Rahlf <basti at redtoad dot de>
 #
 # This program is release under the MIT license. You can find the full text of

--- a/pytest_localserver/smtp.py
+++ b/pytest_localserver/smtp.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (C) 2011 Sebastian Rahlf <basti at redtoad dot de>
 # with some ideas from http://code.activestate.com/recipes/440690/
 # SmtpMailsink Copyright 2005 Aviarc Corporation


### PR DESCRIPTION
Since none of these files are meant to be run directly as scripts, there's no need to have shebang lines in them, and in fact it could give someone a misleading impression to have them there, so removing them should reduce confusion.

Closes #47