### PR TITLE
Move SMTP driver code into a function

### DIFF
--- a/pytest_localserver/smtp.py
+++ b/pytest_localserver/smtp.py
@@ -156,7 +156,7 @@ class Server(aiosmtpd.controller.Controller):
         return "<smtp.Server %s:%s>" % self.addr
 
 
-if __name__ == "__main__":  # pragma: no cover
+def main():
     import time
 
     server = Server()
@@ -178,3 +178,7 @@ if __name__ == "__main__":  # pragma: no cover
         # support for Python 2.4 dictates that try ... finally is not used
         # together with any except statements
         pass
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pytest_localserver/smtp.py
+++ b/pytest_localserver/smtp.py
@@ -166,18 +166,13 @@ def main():
     print("Type <Ctrl-C> to stop")
 
     try:
-
-        try:
-            while True:
-                time.sleep(1)
-        finally:
-            print("\rstopping...")
-            server.stop()
-
+        while True:
+            time.sleep(1)
     except KeyboardInterrupt:
-        # support for Python 2.4 dictates that try ... finally is not used
-        # together with any except statements
         pass
+    finally:
+        print("\rstopping...")
+        server.stop()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
`pytest_localserver.smtp` allows running itself as a module to start up an SMTP server, which is implemented by a bit of driver code guarded by an `if __name__ == "__main__"` block. Typical best practice is to put that code in a `main()` function, which is what I'm doing in this commit.