### PR TITLE
Ignore AttributeError when shutting down server

### DIFF
--- a/pytest_localserver/http.py
+++ b/pytest_localserver/http.py
@@ -31,7 +31,12 @@ class WSGIServer(threading.Thread):
         self.stop()
 
     def stop(self):
-        self._server.shutdown()
+        try:
+            server = self._server
+        except AttributeError:
+            pass
+        else:
+            server.shutdown()
 
     @property
     def url(self):


### PR DESCRIPTION
It's possible for the _server attribute to not exist if make_server raises an error in the constructor. This usually emits some sort of additional error onto the console that can distract from identifying the real issue.