### PR TITLE
Explicit Python 3.12 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         # Not all Python versions are available for linux AND x64
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
         extra: ['', '-smtp']
         # The forced pytest versions correspond with the lower bounds in tox.ini
         pytest-version: ['', '--force-dep pytest==4', '--force-dep pytest==6.2.4']
@@ -34,14 +34,17 @@ jobs:
           pytest-version: '--force-dep pytest==4'
         - python-version: '3.11'
           pytest-version: '--force-dep pytest==4'
+        - python-version: '3.12'
+          pytest-version: '--force-dep pytest==4'
       fail-fast: false
 
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,6 @@ repos:
         args: [--py3-plus]
 
 -   repo: https://github.com/rhysd/actionlint
-    rev: v1.6.23
+    rev: v1.6.25
     hooks:
     -   id: actionlint-docker

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Testing",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39,310,311,py3}{,-smtp},lint
+envlist = py{35,36,37,38,39,310,311,312,py3}{,-smtp},lint
 recreate = True
 isolated_build = True
 


### PR DESCRIPTION
This PR adds testing for Python 3.12 and adds it to the list of supported versions.