### PR TITLE
Update README not to specify the wrong type for the SMTP server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,8 @@ poking around in the code itself.
     is the same as ``httpserver`` only with SSL encryption.
 
 ``smtpserver``
-    provides a threaded instance of ``smtpd.SMTPServer`` running on localhost.
+    provides a threaded SMTP server, with an API similar to ``smtpd.SMTPServer``,
+    (the deprecated class from the Python standard library) running on localhost.
     It has the following attributes:
 
     * ``addr`` - server address as tuple (host as str, port as int)


### PR DESCRIPTION
The README file had said that the SMTP server would be an instance of `smtpd.SMTPServer`, but that's actually no longer true now that we don't use the smtpd module anymore. In this commit I'm updating that bit of documentation not to specifically reference `smtpd.SMTPServer`. Instead, it's a bit vague about what kind of SMTP server is provided, only promising an API "similar to `smtpd.SMTPServer`". This gives us freedom to change the exact API offered by that class if necessary.

Closes #51