### PR TITLE
Fix pre-commit errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,7 @@ repos:
     rev: v1.6.25
     hooks:
     -   id: actionlint-docker
+
+ci:
+    skip:
+    -   actionlint-docker

--- a/pytest_localserver/https.py
+++ b/pytest_localserver/https.py
@@ -126,9 +126,12 @@ class SecureContentServer(ContentServer):
     def certificate(self):
         """
         Returns the path to the server's SSL/TLS certificate file.
-        Clients can use this path to access and verify the server's identity by incorporating the certificate.
+        Clients can use this path to access and verify the server's identity by
+        incorporating the certificate.
 
-        Note: Do not rely on having a stable filesystem path for the returned certificate path across different versions or test runs.
+        .. note::
+            Do not rely on having a stable filesystem path for the returned
+            certificate path across different versions or test runs.
         """
         return self._cert
 


### PR DESCRIPTION
A long line in this docstring was causing the flake8 pre-commit check to fail, so I edited the comment to be compliant. I shortened the lines to about 80 characters for consistency with other comments, even though that's more of a change than is strictly required to pass flake8. With this change, we can start requiring pre-commit to pass for all merges.

I also changed a note to use Restructured Text syntax, for compatibility with other docstrings in the project.

I also changed the pre-commit configuration to skip the actionlint hook, because it's not configured to run Docker hooks.