### PR TITLE
Remove unused `six` from tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ deps =
     pytest >=4, <8; python_version<'3.10'
     pytest >=6.2.4, <8; python_version>='3.10'
     pytest-cov
-    six
     requests
 extras =
     smtp: smtp


### PR DESCRIPTION
Resolves https://github.com/pytest-dev/pytest-localserver/issues/76