### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,12 +22,6 @@ jobs:
         pytest-version: ['', '--force-dep pytest==4', '--force-dep pytest==6.2.4']
         include:
         - os: 'ubuntu-20.04'
-          python-version: '3.5'
-          pytest-version: ''
-        - os: 'ubuntu-20.04'
-          python-version: '3.5'
-          pytest-version: '--force-dep pytest==4'
-        - os: 'ubuntu-20.04'
           python-version: '3.6'
         exclude:
         - python-version: '3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,5 @@ build-backend = "setuptools.build_meta"
 write_to = "pytest_localserver/_version.py"
 
 [tool.black]
-target-version = ['py35']
+target-version = ['py36']
 line-length = 120

--- a/pytest_localserver/smtp.py
+++ b/pytest_localserver/smtp.py
@@ -95,16 +95,7 @@ class Server(aiosmtpd.controller.Controller):
 
     @property
     def accepting(self):
-        try:
-            return self.server.is_serving()
-        except AttributeError:
-            # asyncio.base_events.Server.is_serving() only exists in Python 3.6
-            # and up. For Python 3.5, asyncio.base_events.BaseEventLoop.is_running()
-            # is a close approximation; it should mostly return the same value
-            # except for brief periods when the server is starting up or shutting
-            # down. Once we drop support for Python 3.5, this branch becomes
-            # unnecessary.
-            return self.loop.is_running()
+        return self.server.is_serving()
 
     # for aiosmtpd <1.4
     if not hasattr(aiosmtpd.controller.Controller, "_trigger_server"):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     long_description=read("README.rst"),
     url="https://github.com/pytest-dev/pytest-localserver",
     packages=["pytest_localserver"],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=["werkzeug>=0.10"],
     extras_require={
         "smtp": [
@@ -59,7 +59,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39,310,311,312,py3}{,-smtp},lint
+envlist = py{36,37,38,39,310,311,312,py3}{,-smtp},lint
 recreate = True
 isolated_build = True
 


### PR DESCRIPTION
Our CI jobs have stopped working with Python 3.5 since pip is no longer able to upgrade itself. Perhaps there was a recent change in PyPI's SSL certificate that makes it unable to be verified on Python 3.5, at least within GitHub Actions. Since Python 3.5 is long past EOL, we don't think it's worth putting in any work to get that job working again, so this pull request drops support for Python 3.5.

The package may still work with Python 3.5, and anyone who wants to try it is welcome to give it a go, but it's no longer officially supported and we are not putting in any effort to keep it working on 3.5 in future versions.