### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         # Not all Python versions are available for linux AND x64
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
         extra: ['', '-smtp']
         # The forced pytest versions correspond with the lower bounds in tox.ini
         pytest-version: ['', '--force-dep pytest==4', '--force-dep pytest==6.2.4']
@@ -29,6 +29,8 @@ jobs:
         - python-version: '3.11'
           pytest-version: '--force-dep pytest==4'
         - python-version: '3.12'
+          pytest-version: '--force-dep pytest==4'
+        - python-version: '3.13'
           pytest-version: '--force-dep pytest==4'
       fail-fast: false
 

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Software Development :: Testing",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310,311,312,py3}{,-smtp},lint
+envlist = py{36,37,38,39,310,311,312,313,py3}{,-smtp},lint
 recreate = True
 isolated_build = True
 


### PR DESCRIPTION
This PR adds testing for Python 3.13 and adds it to the list of supported versions, now that we've had the first release candidate of that version.