### PR TITLE
Bump required pytest version to 4.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,19 +19,19 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
         extra: ['', '-smtp']
         # The forced pytest versions correspond with the lower bounds in tox.ini
-        pytest-version: ['', '--force-dep pytest==4', '--force-dep pytest==6.2.4']
+        pytest-version: ['', '--force-dep pytest==4.6', '--force-dep pytest==6.2.4']
         include:
         - os: 'ubuntu-20.04'
           python-version: '3.6'
         exclude:
         - python-version: '3.10'
-          pytest-version: '--force-dep pytest==4'
+          pytest-version: '--force-dep pytest==4.6'
         - python-version: '3.11'
-          pytest-version: '--force-dep pytest==4'
+          pytest-version: '--force-dep pytest==4.6'
         - python-version: '3.12'
-          pytest-version: '--force-dep pytest==4'
+          pytest-version: '--force-dep pytest==4.6'
         - python-version: '3.13'
-          pytest-version: '--force-dep pytest==4'
+          pytest-version: '--force-dep pytest==4.6'
       fail-fast: false
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     # works with your code. Don't forget to modify the corresponding entries in
     # the Github workflows configuration file if you do change these lower
     # bounds.
-    pytest >=4, <8; python_version<'3.10'
+    pytest >=4.6, <8; python_version<'3.10'
     pytest >=6.2.4, <8; python_version>='3.10'
     pytest-cov
     requests


### PR DESCRIPTION
We have started getting an error with `pytest>=4,<4.6` when `setuptools>=71` (or `typeguard>=4.2`) is also installed, due to a conflict with older `pytest` and `setuptools`' vendored version of `typeguard`. Out of various ways to resolve this conflict, this is the only one that doesn't involve putting an upper bound on the version of some package.

It should still be technically possible to use older versions of `pytest` along with `setuptools<71`, if someone really needs to do that, but there isn't any way to express that dependency constraint, and I'm not going to go to any trouble to support long-obsolete versions of packages.

# Testing notes

- If I add `typeguard<4.2` to the test requirements in `tox.ini`, then I run into agronholm/typeguard#343
- If I add `setuptools<71` then everything works (since it doesn't require any version of `typeguard` at all)
- If I change to requiring `pytest>=6.2`, then again everything works
- It turns out I can go as far back as `pytest>=4.6` and still everything works; it looks like there was a change to how and when plugins are loaded in 4.6 that affects this

Hence I'm bumping to 4.6 in this PR.

Closes #97