### PR TITLE
Increase max allowed pytest version to 9

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,8 @@ deps =
     # works with your code. Don't forget to modify the corresponding entries in
     # the Github workflows configuration file if you do change these lower
     # bounds.
-    pytest >=4.6, <8; python_version<'3.10'
-    pytest >=6.2.4, <8; python_version>='3.10'
+    pytest >=4.6, <9; python_version<'3.10'
+    pytest >=6.2.4, <9; python_version>='3.10'
     pytest-cov
     requests
 extras =


### PR DESCRIPTION
pytest 8 has been out for a while; it's long past time we officially added support for it. This will allow people to use this plugin along with pytest 8.