### PR TITLE
Run Python 3.7 tests only on Ubuntu 22.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,13 +16,17 @@ jobs:
         # Not all Python versions are available for linux AND x64
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.8', 'pypy-3.9']
         extra: ['', '-smtp']
         # The forced pytest versions correspond with the lower bounds in tox.ini
         pytest-version: ['', '--force-dep pytest==4.6', '--force-dep pytest==6.2.4']
         include:
         - os: 'ubuntu-20.04'
           python-version: '3.6'
+        - os: 'ubuntu-22.04'
+          python-version: '3.7'
+        - os: 'ubuntu-22.04'
+          python-version: 'pypy-3.7'
         exclude:
         - python-version: '3.10'
           pytest-version: '--force-dep pytest==4.6'


### PR DESCRIPTION
GitHub Actions is delivering errors when running tests for Python 3.7 on the latest Ubuntu runners (24.04), because Python 3.7 is not available for that runner version anymore. So I'm removing 3.7 from the list of versions tested on the latest Ubuntu and adding a test for it on Ubuntu 22.04. I gave Pypy 3.7 the same treatment. This should fix the recent CI failures.