### PR TITLE
Drop support for EOL Python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,6 @@ jobs:
         # The forced pytest versions correspond with the lower bounds in tox.ini
         pytest-version: ['', '--force-dep pytest==4.6', '--force-dep pytest==6.2.4']
         include:
-        - os: 'ubuntu-20.04'
-          python-version: '3.6'
         - os: 'ubuntu-22.04'
           python-version: '3.7'
         - os: 'ubuntu-22.04'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     rev: v3.19.1
     hooks:
     -   id: pyupgrade
-        args: [--py3-plus]
+        args: [--py37-plus]
 
 -   repo: https://github.com/rhysd/actionlint
     rev: v1.7.7

--- a/pytest_localserver/http.py
+++ b/pytest_localserver/http.py
@@ -56,7 +56,7 @@ class Chunked(enum.Enum):
 def _encode_chunk(chunk, charset):
     if isinstance(chunk, str):
         chunk = chunk.encode(charset)
-    return "{:x}".format(len(chunk)).encode(charset) + b"\r\n" + chunk + b"\r\n"
+    return f"{len(chunk):x}".encode(charset) + b"\r\n" + chunk + b"\r\n"
 
 
 class ContentServer(WSGIServer):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     long_description=read("README.rst"),
     url="https://github.com/pytest-dev/pytest-localserver",
     packages=["pytest_localserver"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=["werkzeug>=0.10"],
     extras_require={
         "smtp": [
@@ -59,7 +59,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -241,7 +241,7 @@ def _format_chunk(chunk):
     if len(r) <= 40:
         return r
     else:
-        return r[:13] + "..." + r[-14:] + " (length {})".format(len(chunk))
+        return r[:13] + "..." + r[-14:] + f" (length {len(chunk)})"
 
 
 def _compare_chunks(expected, actual):
@@ -252,7 +252,7 @@ def _compare_chunks(expected, actual):
             for i, (e, a) in enumerate(itertools.zip_longest(expected, actual, fillvalue="<end>")):
                 if e != a:
                     message += [
-                        "  Chunks differ at index {}:".format(i),
+                        f"  Chunks differ at index {i}:",
                         "    Expected: " + (repr(expected[i : i + 5]) + "..." if e != "<end>" else "<end>"),
                         "    Found:    " + (repr(actual[i : i + 5]) + "..." if a != "<end>" else "<end>"),
                     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310,311,312,313,py3}{,-smtp},lint
+envlist = py{37,38,39,310,311,312,313,py3}{,-smtp},lint
 recreate = True
 isolated_build = True
 


### PR DESCRIPTION
GitHub Actions has deprecated the `ubuntu-20.04` runner, and it'll be fully unsupported by 2025-04-01: https://github.com/actions/runner-images/issues/11101

I spotted this repo is still using to test Python 3.6, which has been end-of-life since 2021, so it's definitely time to drop support:

<img width="778" alt="image" src="https://github.com/user-attachments/assets/c9c1a6e2-dc57-464a-aa92-7f02dcb6e261" />

https://devguide.python.org/versions/

Python 3.7 and 3.8 are also EOL, and I recommend dropping them too. I haven't done so in this PR, but I'm happy to include it here or in a new PR if you like.