### PR TITLE
Block broken version of pytest-cov

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     # bounds.
     pytest >=4.6, <9; python_version<'3.10'
     pytest >=6.2.4, <9; python_version>='3.10'
-    pytest-cov
+    pytest-cov !=6.2.0
     requests
 extras =
     smtp: smtp


### PR DESCRIPTION
Recently, version 6.2.0 of [pytest-cov](https://github.com/pytest-dev/pytest-cov) was released with support for new pluggy hookwrappers, which require `pluggy>=1.2` and `pytest>=6.2.5`, but the dependency metadata wasn't updated to reflect these requirements. There was an immediate followup release, pytest-cov 6.2.1, that fixed the metadata problem (pytest-dev/pytest-cov#200), but that still leaves version 6.2.0 as one that pip thinks should be safe to use with `pytest<6.2.5`, even though it actually isn't. (Perhaps 6.2.0 should be yanked to deal with this, but it looks like it probably won't be.)

Since some of our tests run with pytest 6.2.4, we were getting failures because of this mismatch. Accordingly, in this PR I'm manually blocking pytest-cov 6.2.0 to avoid the failure.