### PR TITLE
Update black target version to Python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,5 @@ build-backend = "setuptools.build_meta"
 write_to = "pytest_localserver/_version.py"
 
 [tool.black]
-target-version = ['py36']
+target-version = ['py37']
 line-length = 120


### PR DESCRIPTION
Since the minimum required version of Python in the project's dependencies has been updated to 3.7 (see #113), it makes sense to bump the black target version to match.