### PR TITLE
Remove driver code

### DIFF
--- a/pytest_localserver/http.py
+++ b/pytest_localserver/http.py
@@ -5,7 +5,6 @@
 import enum
 import itertools
 import json
-import sys
 import threading
 
 from werkzeug.datastructures import Headers
@@ -161,29 +160,3 @@ class ContentServer(WSGIServer):
         self.store_request_data = store_request_data
         if headers:
             self.headers = Headers(headers)
-
-
-if __name__ == "__main__":  # pragma: no cover
-    import os.path
-    import time
-
-    app = ContentServer()
-    server = WSGIServer(application=app)
-    server.start()
-
-    print("HTTP server is running at %s" % server.url)
-    print("Type <Ctrl-C> to stop")
-
-    try:
-        path = sys.argv[1]
-    except IndexError:
-        path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "README.rst")
-
-    app.serve_content(open(path).read(), 302)
-
-    try:
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        print("\rstopping...")
-    server.stop()

--- a/pytest_localserver/https.py
+++ b/pytest_localserver/https.py
@@ -133,32 +133,3 @@ class SecureContentServer(ContentServer):
             certificate path across different versions or test runs.
         """
         return self._cert
-
-
-if __name__ == "__main__":  # pragma: no cover
-
-    import sys
-    import time
-
-    print("Using certificate %s." % DEFAULT_CERTIFICATE)
-
-    server = SecureContentServer()
-    server.start()
-    server.logging = True
-
-    print("HTTPS server is running at %s" % server.url)
-    print("Type <Ctrl-C> to stop")
-
-    try:
-        path = sys.argv[1]
-    except IndexError:
-        path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "README.rst")
-
-    server.serve_content(open(path).read(), 302)
-
-    try:
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        print("\rstopping...")
-    server.stop()

--- a/pytest_localserver/smtp.py
+++ b/pytest_localserver/smtp.py
@@ -142,26 +142,3 @@ class Server(aiosmtpd.controller.Controller):
 
     def __repr__(self):  # pragma: no cover
         return "<smtp.Server %s:%s>" % self.addr
-
-
-def main():
-    import time
-
-    server = Server()
-    server.start()
-
-    print("SMTP server is running on %s:%i" % server.addr)
-    print("Type <Ctrl-C> to stop")
-
-    try:
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        pass
-    finally:
-        print("\rstopping...")
-        server.stop()
-
-
-if __name__ == "__main__":  # pragma: no cover
-    main()


### PR DESCRIPTION
Since this package is meant to be installed and imported, it doesn't really make sense anymore to have code in the modules that allows those modules to be executed as individual Python scripts. So I'm removing that code in this commit.

I considered adding tests to replicate the functionality of the code being removed, but there didn't seem to be much point. The removed code just does a basic check that the server can start and stop, and relies on some external client to send HTTP or SMTP requests, and our existing tests cover all that functionality already.